### PR TITLE
HTML Encode credentials when including in report

### DIFF
--- a/EyeWitness.py
+++ b/EyeWitness.py
@@ -290,7 +290,7 @@ def tableMaker(web_table_index, website_url, possible_creds, web_page, content_e
     web_table_index += "<a href=\"" + website_url + "\" target=\"_blank\">" + website_url + "</a><br>"
 
     if possible_creds is not None:
-        web_table_index += "<br><b>Default credentials:</b> " + possible_creds + "<br>"
+        web_table_index += "<br><b>Default credentials:</b> " + htmlEncode(possible_creds) + "<br>"
 
     try:
         for key, value in web_page.headers.items():


### PR DESCRIPTION
- In case there are special characters in the creds, or if someone tampers with your signatures.txt file and puts script in there (less likley :)
