### PR TITLE
Improve NMap XML parsing a bit for finding non-common HTTPS hosts

### DIFF
--- a/EyeWitness.py
+++ b/EyeWitness.py
@@ -114,10 +114,11 @@ def logistics(url_file):
                         if ports.find('state').get('state') == 'open':
                             port = ports.attrib.get('portid')
                             try:
-                                service = ports.find('service').get('name')
-                                if int(port) in http_ports or 'http' in service.lower():
+                                service = ports.find('service').get('name').lower()
+                                tunnel = ports.find('service').get('tunnel').lower()
+                                if int(port) in http_ports or 'http' in service:
                                     protocol = 'http'
-                                    if int(port) in https_ports or 'https' in service.lower():
+                                    if int(port) in https_ports or 'https' in service or ('http' in service and 'ssl' in tunnel):
                                         protocol = 'https'
                                     urlBuild = '%s://%s:%s' % (protocol,target,port)
                                     if urlBuild not in urls:


### PR DESCRIPTION
- Nmap states if a given port is HTTP and if it's going over SSL. Now treat unknown ports that are SSL endpoints as HTTPS.

Now something like this will be fetched using HTTPS, instead of HTTP as before:

``` xml
<ports>
        <port protocol="tcp" portid="7839">
                <state state="open" reason="syn-ack" reason_ttl="0"/>
                <service name="http" product="nginx" tunnel="ssl" method="probed" conf="10">
                        <cpe>cpe:/a:igor_sysoev:nginx</cpe>
                </service>
        </port>
</ports>
```

Should also treat SSL services running on ports in the http_ports list as HTTPS (which would be correct).
