### PR TITLE
Use default_popup_response=True in ghost.open

### DIFF
--- a/EyeWitness.py
+++ b/EyeWitness.py
@@ -287,7 +287,7 @@ def htmlEncode(dangerous_data):
 def ghostCapture(screen_url, rep_fold, screen_name, ewitness_dir_path):
     # Try to get our screenshot and source code of the page
     # Write both out to disk if possible (if we can get one, we can get the other)
-    ghost_page, ghost_extra_resources = ghost.open(screen_url, auth=('none', 'none'))
+    ghost_page, ghost_extra_resources = ghost.open(screen_url, auth=('none', 'none'), default_popup_response=True)
     ghost.capture_to(ewitness_dir_path + "/" + rep_fold + "/screens/" + screen_name)
     return ghost_page, ghost_extra_resources
 


### PR DESCRIPTION
- Using default_popup_response=True in ghost.open() calls appears to click through any popups or prompts that may come about, useful for invalid certs or JS popups that may arise and cause timeouts otherwise.
- Feature details in ghost (best I could find): https://github.com/jeanphix/Ghost.py/commit/8522c532a39bbc2f73799afe15269e0d426bbd0d

This allowed me to successfully get screenshots of some sites that had self-signed SSL certs in use. _Maybe_ this should be a configurable option in the future.
