### PR TITLE
Modified file_names to use '.' delimiter. 

### DIFF
--- a/EyeWitness.py
+++ b/EyeWitness.py
@@ -239,8 +239,8 @@ def default_creds(page_content, full_file_path, local_system_os):
 def file_names(url_given):
     url_given = url_given.strip()
     pic_name = url_given
-    pic_name = pic_name.replace("//", "")
-    pic_name = pic_name.replace(":", "")
+    pic_name = pic_name.replace("://", ".")
+    pic_name = pic_name.replace(":", ".")
     pic_name = pic_name.replace("/", "")
     src_name = pic_name + ".txt"
     pic_name = pic_name + ".png"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ EyeWitness is designed to take screenshots of websites, provide some server head
 
 Inspiration came from Tim Tomes's PeepingTom Script.  I just wanted to change some things, and then it became a thought exercise to write it myself.
 
-EyeWitness is designed to run on Kali Linux.  It will auto detect the file you give it with the -f flag as either being a text file with URLs on each new line, nmap xml output, or nessus xml output.  The -t (timeout) flag is completely optional, and lets you provice the max time to wait when trying to render and screenshot a web page.  The --open flag, which is optional, will open the URL in a new tab within iceweasel.
+EyeWitness is designed to run on Kali Linux.  It will auto detect the file you give it with the -f flag as either being a text file with URLs on each new line, nmap xml output, or nessus xml output.  The -t (timeout) flag is completely optional, and lets you provide the max time to wait when trying to render and screenshot a web page.  The --open flag, which is optional, will open the URL in a new tab within iceweasel.
 
 Supported Linux Distros:
 


### PR DESCRIPTION
Also a minor typo correction in the README.

The delimiter was added to make parsing the directory and file names easier. Port numbers concatenated to the end of the file names based upon ip addresses were problemmatic to remove.
