### PR TITLE
Update tools (Search, Recategorize, MiktoList) to Python3

### DIFF
--- a/Python/MiktoList.py
+++ b/Python/MiktoList.py
@@ -11,34 +11,34 @@ from modules.db_manager import DB_Manager
 def open_file_input(cli_parsed):
     files = glob.glob(os.path.join(cli_parsed.d, 'report.html'))
     if len(files) > 0:
-        print 'Would you like to open the report now? [Y/n]',
+        print('Would you like to open the report now? [Y/n]', end=' ')
         while True:
             try:
-                response = raw_input().lower()
-                if response is "":
+                response = input().lower()
+                if response == "":
                     return True
                 else:
                     return strtobool(response)
             except ValueError:
-                print "Please respond with y or n",
+                print('Please respond with y or n', end=' ')
     else:
-        print '[*] No report files found to open, perhaps no hosts were successful'
+        print('[*] No report files found to open, perhaps no hosts were successful')
         return False
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        print 'Create a file containing urls for splash pages and 404s to feed to Mikto\n'
-        print '[*] Usage: python MiktoList.py <dbpath> <outfile>'
-        print 'DBPath should point to the ew.db file in your EyeWitness output folder'
+        print('Create a file containing urls for splash pages and 404s to feed to Mikto\n')
+        print('[*] Usage: python MiktoList.py <dbpath> <outfile>')
+        print('DBPath should point to the ew.db file in your EyeWitness output folder')
         sys.exit()
     db_path = sys.argv[1]
     outfile = sys.argv[2]
     if not os.path.isfile(db_path):
-        print '[*] No valid db path provided'
+        print('[*] No valid db path provided')
         sys.exit()
     dbm = DB_Manager(db_path)
     dbm.open_connection()
     results = dbm.get_mikto_results()
     with open(outfile, 'w') as f:
         f.writelines([x.remote_system + '\n' for x in results])
-    print 'Wrote {0} URLs to {1}'.format(len(results), outfile)
+    print('Wrote {0} URLs to {1}'.format(len(results), outfile))

--- a/Python/Recategorize.py
+++ b/Python/Recategorize.py
@@ -12,7 +12,7 @@ from modules.reporting import sort_data_and_write
 def open_file_input(cli_parsed):
     files = glob.glob(os.path.join(cli_parsed.d, 'report.html'))
     if len(files) > 0:
-        print('Would you like to open the report now? [Y/n]'),
+        print('Would you like to open the report now? [Y/n]', end=' ')
         while True:
             try:
                 response = input().lower()
@@ -21,9 +21,9 @@ def open_file_input(cli_parsed):
                 else:
                     return strtobool(response)
             except ValueError:
-                print("Please respond with y or n"),
+                print('Please respond with y or n', end=' ')
     else:
-        print ('[*] No report files found to open, perhaps no hosts were successful')
+        print('[*] No report files found to open, perhaps no hosts were successful')
         return False
 
 if __name__ == "__main__":
@@ -45,7 +45,7 @@ if __name__ == "__main__":
     for f in files:
         os.remove(f)
     results = dbm.recategorize()
-    print ('Writing report')
+    print('Writing report')
     sort_data_and_write(cli_parsed, results)
     newfiles = glob.glob(cli_parsed.d + '/report.html')
     if open_file_input(cli_parsed):

--- a/Python/Search.py
+++ b/Python/Search.py
@@ -13,40 +13,40 @@ from modules.reporting import search_report
 def open_file_input(cli_parsed):
     files = glob.glob(os.path.join(cli_parsed.d, 'search.html'))
     if len(files) > 0:
-        print 'Would you like to open the report now? [Y/n]',
+        print('Would you like to open the report now? [Y/n]', end=' ')
         while True:
             try:
-                response = raw_input().lower()
-                if response is "":
+                response = input().lower()
+                if response == "":
                     return True
                 else:
                     return strtobool(response)
             except ValueError:
-                print "Please respond with y or n",
+                print("Please respond with y or n", end=' ')
     else:
-        print '[*] No report files found to open, perhaps no hosts were successful'
+        print('[*] No report files found to open, perhaps no hosts were successful')
         return False
 
 
 if __name__ == "__main__":
     if len(sys.argv) < 3:
-        print 'Search a previously completed EyeWitness scan (HTTP page title/source)\n'
-        print '[*] Usage: python Search.py <dbpath> <searchterm>'
-        print 'DBPath should point to the ew.db file in your EyeWitness output folder'
+        print('Search a previously completed EyeWitness scan (HTTP page title/source)\n')
+        print('[*] Usage: python Search.py <dbpath> <searchterm>')
+        print('DBPath should point to the ew.db file in your EyeWitness output folder')
         sys.exit()
     db_path = sys.argv[1]
     if not os.path.isfile(db_path):
-        print '[*] No valid db path provided'
+        print('[*] No valid db path provided')
         sys.exit()
     search_term = sys.argv[2]
     dbm = DB_Manager(db_path)
     dbm.open_connection()
     results = dbm.search_for_term(search_term)
     if len(results) == 0:
-        print 'No results found!'
+        print('No results found!')
         sys.exit()
     else:
-        print 'Found {0} Results!'.format(str(len(results)))
+        print('Found {0} Results!'.format(len(results)))
     cli_parsed = dbm.get_options()
     cli_parsed.results = 25
     cli_parsed.d = os.path.dirname(db_path)

--- a/Python/modules/db_manager.py
+++ b/Python/modules/db_manager.py
@@ -191,6 +191,13 @@ class DB_Manager(object):
         rows = c.execute("SELECT * FROM http WHERE complete=1").fetchall()
         for row in rows:
             o = pickle.loads(row['object'])
+
+            if type(o.source_code) is str:
+                o.source_code = o.source_code.encode()
+
+            if type(o.page_title) is str:
+                o.page_title = o.page_title.encode()
+
             uadat = c.execute("SELECT * FROM ua WHERE parent_id=?",
                               (o.id,)).fetchall()
             for ua in uadat:

--- a/Python/modules/db_manager.py
+++ b/Python/modules/db_manager.py
@@ -204,8 +204,13 @@ class DB_Manager(object):
                 uao = pickle.loads(ua['object'])
                 if uao is not None:
                     o.add_ua_data(uao)
-            if o.error_state is None and o.source_code is not None and o.page_title is not None:
-                if search.encode() in o.source_code or search.encode() in o.page_title:
+
+            # if o.source_code or o.page_title are None, set them to empty strings for comparison
+            source_code = '' if o.source_code is None else o.source_code
+            page_title = '' if o.page_title is None else o.page_title
+
+            if o.error_state is None:
+                if search.encode() in source_code or search.encode() in page_title:
                     finished.append(o)
         c.close()
         return finished

--- a/Python/modules/db_manager.py
+++ b/Python/modules/db_manager.py
@@ -198,7 +198,7 @@ class DB_Manager(object):
                 if uao is not None:
                     o.add_ua_data(uao)
             if o.error_state is None:
-                if search in o.source_code or search in o.page_title:
+                if search.encode() in o.source_code or search.encode() in o.page_title:
                     finished.append(o)
         c.close()
         return finished

--- a/Python/modules/db_manager.py
+++ b/Python/modules/db_manager.py
@@ -204,7 +204,7 @@ class DB_Manager(object):
                 uao = pickle.loads(ua['object'])
                 if uao is not None:
                     o.add_ua_data(uao)
-            if o.error_state is None:
+            if o.error_state is None and o.source_code is not None and o.page_title is not None:
                 if search.encode() in o.source_code or search.encode() in o.page_title:
                     finished.append(o)
         c.close()

--- a/Python/modules/db_manager.py
+++ b/Python/modules/db_manager.py
@@ -206,8 +206,8 @@ class DB_Manager(object):
                     o.add_ua_data(uao)
 
             # if o.source_code or o.page_title are None, set them to empty strings for comparison
-            source_code = '' if o.source_code is None else o.source_code
-            page_title = '' if o.page_title is None else o.page_title
+            source_code = b'' if o.source_code is None else o.source_code
+            page_title = b'' if o.page_title is None else o.page_title
 
             if o.error_state is None:
                 if search.encode() in source_code or search.encode() in page_title:


### PR DESCRIPTION
Closes #427

Updated Search.py, Recategorize.py, and MiktoList.py to be Python3-compatible.

Required changing modules/db_manager.py `search_for_term` function to properly encode str/byte types.

All scripts tested and working on Parrot using Python 3.9.2.

Feedback welcome as always. Thanks folks!