### PR TITLE
Setup Script Rewrite

### DIFF
--- a/Python/setup/requirements.txt
+++ b/Python/setup/requirements.txt
@@ -1,0 +1,5 @@
+fuzzywuzzy
+selenium==4.9.1
+python-Levenshtein
+pyvirtualdisplay
+netaddr

--- a/Python/setup/setup.sh
+++ b/Python/setup/setup.sh
@@ -9,7 +9,7 @@ get_gecko() {
 
     # Get download links for latest geckodriver via GitHub API
     local latest_geckos=$(curl -s https://api.github.com/repos/mozilla/geckodriver/releases/latest \
-            | grep browser_download_url | cut -d':' -f2,3 | tr -d \" | tr -d '[:blank:]')
+            | jq '.assets.[].browser_download_url' | tr -d \")
     
     # Construct appropriate download URL (or exit if unsupported arch)
     local gecko_url="";
@@ -41,19 +41,19 @@ install_deps() {
     case ${os_id} in
         debian|kali)
             apt-get update
-            apt-get install -y wget curl cmake python3 xvfb python3-pip python3-netaddr python3-dev firefox-esr tar
+            apt-get install -y wget curl jq cmake python3 xvfb python3-pip python3-netaddr python3-dev firefox-esr tar
             ;;
         ubuntu|linuxmint)
             apt-get update
-            apt-get install -y wget curl cmake python3 xvfb python3-pip python3-netaddr python3-dev firefox x11-utils tar
+            apt-get install -y wget curl jq cmake python3 xvfb python3-pip python3-netaddr python3-dev firefox x11-utils tar
             ;;
         arch|manjaro)
             pacman -Syu
-            pacman -S --noconfirm wget curl cmake python3 python-xvfbwrapper python-pip python-netaddr firefox tar
+            pacman -S --noconfirm wget curl jq cmake python3 python-xvfbwrapper python-pip python-netaddr firefox tar
             ;;
         alpine)
             apk update
-            apk add wget curl cmake python3 xvfb py-pip py-netaddr python3-dev firefox tar
+            apk add wget curl jq cmake python3 xvfb py-pip py-netaddr python3-dev firefox tar
 
             # from https://stackoverflow.com/questions/58738920/running-geckodriver-in-an-alpine-docker-container
             # Get all the prereqs
@@ -67,7 +67,7 @@ install_deps() {
             apk add firefox-esr=60.9.0-r0
             ;;
         centos|rocky|fedora)
-            yum install -y wget curl python3 xorg-x11-server-Xvfb python3-pip firefox gcc cmake python3-devel gcc cmake python3-devel tar
+            yum install -y wget curl jq python3 xorg-x11-server-Xvfb python3-pip firefox gcc cmake python3-devel gcc cmake python3-devel tar
             ;;
         *)
             echo "[-] Error: Unsupported Operating System ID: ${os_id}"

--- a/Python/setup/setup.sh
+++ b/Python/setup/setup.sh
@@ -9,7 +9,7 @@ get_gecko() {
 
     # Get download links for latest geckodriver via GitHub API
     local latest_geckos=$(curl -s https://api.github.com/repos/mozilla/geckodriver/releases/latest \
-            | jq '.assets.[].browser_download_url' | tr -d \")
+            | jq '.assets[].browser_download_url' | tr -d \")
     
     # Construct appropriate download URL (or exit if unsupported arch)
     local gecko_url="";

--- a/Python/setup/setup.sh
+++ b/Python/setup/setup.sh
@@ -65,10 +65,7 @@ install_deps() {
             apk add firefox-esr=60.9.0-r0
             ;;
         centos|rocky|fedora)
-            yum install -y wget curl python3 xorg-x11-server-Xvfb python3-pip firefox
-            yum install -y gcc
-            yum install -y cmake
-            yum install -y python3-devel
+            yum install -y wget curl python3 xorg-x11-server-Xvfb python3-pip firefox gcc cmake python3-devel gcc cmake python3-devel
             ;;
         *)
             echo "[-] Error: Unsupported Operating System ID: ${os_id}"

--- a/Python/setup/setup.sh
+++ b/Python/setup/setup.sh
@@ -77,7 +77,7 @@ install_deps() {
     esac
 
     # PEP 668 workaround
-    PIP_BREAK_SYSTEM_PACKAGES=1
+    export PIP_BREAK_SYSTEM_PACKAGES=1
 
     echo
     echo "[*] Installing Python dependencies..."

--- a/Python/setup/setup.sh
+++ b/Python/setup/setup.sh
@@ -39,19 +39,19 @@ install_deps() {
     case ${os_id} in
         debian|kali)
             apt-get update
-            apt-get install -y wget curl cmake python3 xvfb python3-pip python3-netaddr python3-dev firefox-esr
+            apt-get install -y wget curl cmake python3 xvfb python3-pip python3-netaddr python3-dev firefox-esr tar
             ;;
         ubuntu|linuxmint)
             apt-get update
-            apt-get install -y wget curl cmake python3 xvfb python3-pip python3-netaddr python3-dev firefox x11-utils
+            apt-get install -y wget curl cmake python3 xvfb python3-pip python3-netaddr python3-dev firefox x11-utils tar
             ;;
         arch|manjaro)
             pacman -Syu
-            pacman -S --noconfirm wget curl cmake python3 python-xvfbwrapper python-pip python-netaddr firefox
+            pacman -S --noconfirm wget curl cmake python3 python-xvfbwrapper python-pip python-netaddr firefox tar
             ;;
         alpine)
             apk update
-            apk add wget curl cmake python3 xvfb py-pip py-netaddr python3-dev firefox
+            apk add wget curl cmake python3 xvfb py-pip py-netaddr python3-dev firefox tar
 
             # from https://stackoverflow.com/questions/58738920/running-geckodriver-in-an-alpine-docker-container
             # Get all the prereqs
@@ -65,7 +65,7 @@ install_deps() {
             apk add firefox-esr=60.9.0-r0
             ;;
         centos|rocky|fedora)
-            yum install -y wget curl python3 xorg-x11-server-Xvfb python3-pip firefox gcc cmake python3-devel gcc cmake python3-devel
+            yum install -y wget curl python3 xorg-x11-server-Xvfb python3-pip firefox gcc cmake python3-devel gcc cmake python3-devel tar
             ;;
         *)
             echo "[-] Error: Unsupported Operating System ID: ${os_id}"

--- a/Python/setup/setup.sh
+++ b/Python/setup/setup.sh
@@ -70,6 +70,7 @@ install_deps() {
         *)
             echo "[-] Error: Unsupported Operating System ID: ${os_id}"
             popd >/dev/null
+            exit 1
             ;;
     esac
 

--- a/Python/setup/setup.sh
+++ b/Python/setup/setup.sh
@@ -2,6 +2,7 @@
 # Original script by @themightyshiv
 # Rewritten by moth@bhis (@0x6d6f7468)
 
+# Function for downloading latest geckodriver for the correct CPU architecture
 get_gecko() {
     echo
     echo "[*] Getting latest Gecko driver..."
@@ -32,6 +33,7 @@ get_gecko() {
     rm geckodriver.tar.gz
 }
 
+# Function to install Linux and Python dependencies
 install_deps() {
     echo
     echo "[*] Installing system dependencies..."
@@ -80,14 +82,6 @@ install_deps() {
     python3 -m pip install -r requirements.txt
 }
 
-done_success() {
-    echo
-    echo "[+] Setup script completed successfully. Enjoy EyeWitness! ^_^"
-    echo "[*] Be sure to check out Red Siege!"
-    echo "[*] https://www.redsiege.com"
-    echo
-}
-
 # Make sure we're in the setup directory
 pushd "$(dirname "$0")" >/dev/null
 
@@ -119,5 +113,8 @@ get_gecko
 popd >/dev/null
 
 # Print success message
-done_success
-
+echo
+echo "[+] Setup script completed successfully. Enjoy EyeWitness! ^_^"
+echo "[*] Be sure to check out Red Siege!"
+echo "[*] https://www.redsiege.com"
+echo

--- a/Python/setup/setup.sh
+++ b/Python/setup/setup.sh
@@ -39,19 +39,19 @@ install_deps() {
     case ${os_id} in
         debian|kali)
             apt-get update
-            apt-get install -y wget cmake python3 xvfb python3-pip python3-netaddr python3-dev firefox-esr
+            apt-get install -y wget curl cmake python3 xvfb python3-pip python3-netaddr python3-dev firefox-esr
             ;;
         ubuntu|linuxmint)
             apt-get update
-            apt-get install -y wget cmake python3 xvfb python3-pip python3-netaddr python3-dev firefox x11-utils
+            apt-get install -y wget curl cmake python3 xvfb python3-pip python3-netaddr python3-dev firefox x11-utils
             ;;
         arch|manjaro)
             pacman -Syu
-            pacman -S --noconfirm wget cmake python3 python-xvfbwrapper python-pip python-netaddr firefox
+            pacman -S --noconfirm wget curl cmake python3 python-xvfbwrapper python-pip python-netaddr firefox
             ;;
         alpine)
             apk update
-            apk add wget cmake python3 xvfb py-pip py-netaddr python3-dev firefox
+            apk add wget curl cmake python3 xvfb py-pip py-netaddr python3-dev firefox
 
             # from https://stackoverflow.com/questions/58738920/running-geckodriver-in-an-alpine-docker-container
             # Get all the prereqs
@@ -65,7 +65,7 @@ install_deps() {
             apk add firefox-esr=60.9.0-r0
             ;;
         centos|rocky|fedora)
-            yum install -y wget python3 xorg-x11-server-Xvfb python3-pip firefox
+            yum install -y wget curl python3 xorg-x11-server-Xvfb python3-pip firefox
             yum install -y gcc
             yum install -y cmake
             yum install -y python3-devel

--- a/Python/setup/setup.sh
+++ b/Python/setup/setup.sh
@@ -110,7 +110,7 @@ fi
 # Get some system information
 echo
 echo "[*] Getting system information..."
-os_id=$(grep ^ID= /etc/os-release | cut -d'=' -f2)
+os_id=$(grep ^ID= /etc/os-release | cut -d'=' -f2 | tr -d '"')
 mach_type=$(uname -m)
 
 # Install dependencies

--- a/Python/setup/setup.sh
+++ b/Python/setup/setup.sh
@@ -116,11 +116,11 @@ echo "[*] Getting system information..."
 os_id=$(grep ^ID= /etc/os-release | cut -d'=' -f2)
 mach_type=$(uname -m)
 
-# Get the gecko
-get_gecko
-
 # Install dependencies
 install_deps
+
+# Get the gecko
+get_gecko
 
 # Get out of there!
 popd >/dev/null

--- a/Python/setup/setup.sh
+++ b/Python/setup/setup.sh
@@ -38,12 +38,12 @@ install_deps() {
 
     case ${os_id} in
         debian|kali)
-            apt update
-            apt install -y wget cmake python3 xvfb python3-pip python3-netaddr python3-dev firefox-esr
+            apt-get update
+            apt-get install -y wget cmake python3 xvfb python3-pip python3-netaddr python3-dev firefox-esr
             ;;
         ubuntu|linuxmint)
-            apt update
-            apt install -y wget cmake python3 xvfb python3-pip python3-netaddr python3-dev firefox x11-utils
+            apt-get update
+            apt-get install -y wget cmake python3 xvfb python3-pip python3-netaddr python3-dev firefox x11-utils
             ;;
         arch|manjaro)
             pacman -Syu

--- a/Python/setup/setup.sh
+++ b/Python/setup/setup.sh
@@ -1,473 +1,120 @@
 #!/bin/bash
+# Original script by @themightyshiv
+# Rewritten by moth@bhis (@0x6d6f7468)
 
-# Global Variables
-userid=`id -u`
-osinfo=`cat /etc/issue|cut -d" " -f1|head -n1`
-distinfo=`cat /etc/issue|cut -d" " -f2|head -n1`
-eplpkg='http://linux.mirrors.es.net/fedora-epel/6/i386/epel-release-6-8.noarch.rpm'
-geckodriver_x86_64='https://github.com/mozilla/geckodriver/releases/download/v0.32.0/geckodriver-v0.32.0-linux64.tar.gz'
-geckodriver_x86_32='https://github.com/mozilla/geckodriver/releases/download/v0.32.0/geckodriver-v0.32.0-linux32.tar.gz'
-
-# Setting environment variables
-export TERM=linux
-
-# Clear Terminal (For Prettyness)
-clear
-
-# Print Title
-echo '#######################################################################'
-echo '#                          EyeWitness Setup                           #'
-echo '#######################################################################'
-echo
-
-# Check to make sure you are root!
-# Thanks to @themightyshiv for helping to get a decent setup script out
-if [ "${userid}" != '0' ]; then
-  echo '[Error]: You must run this setup script with root privileges.'
-  echo
-  exit 1
-fi
-#Support for kali 2 and kali rolling
-if [[ `(lsb_release -sd || grep ^PRETTY_NAME /etc/os-release) 2>/dev/null | grep "Kali GNU/Linux.*\(2\|Rolling\)"` ]]; then
-  osinfo="Kali2"
-fi
-
-if [[ `(lsb_release -sd || grep ^PRETTY_NAME /etc/os-release) 2>/dev/null | grep "Parrot GNU/Linux.*\(4\)"` ]]; then
-  osinfo="Parrot"
-fi
-
-if [ -f /etc/issue ];
-then
-  if [[ `cat /etc/issue | cut -d" " -f3 | head -n1 | grep "Alpine"` ]]; then
-    osinfo="Alpine"
-  fi
-fi
-
-if [ -f /etc/redhat-release ];
-then
-  if [[ `cat /etc/redhat-release | grep "CentOS Linux release 7\.[0-9]\.[0-9]\+ (Core)"` ]]; then
-    osinfo="CentOS7"
-  fi
-
-  if [[ `cat /etc/redhat-release | grep "Rocky Linux release 8\.[0-9]"` ]]; then
-    osinfo="RockyLinux8"
-  fi
-fi
-
-# make sure we run from this directory
-pushd . > /dev/null && cd "$(dirname "$0")"
-
-# OS Specific Installation Statement
-case ${osinfo} in
-  # Kali 2 dependency Install
-  Kali2)
-    apt-get update
-    echo '[*] Installing Debian Dependencies'
-    apt-get install -y cmake python3 xvfb python3-pip python3-netaddr python3-dev firefox-esr
+require_root() {
     echo
-    echo '[*] Installing Python Modules'
-    apt install -y python3-fuzzywuzzy python3-pyvirtualdisplay  python3-netaddr python3-levenshtein
-    python3 -m pip install selenium==4.9.1
-    echo
-    cd ../bin/
-    MACHINE_TYPE=`uname -m`
-    if [ ${MACHINE_TYPE} == 'x86_64' ]; then
-      wget ${geckodriver_x86_64}
-      tar -xvf geckodriver-v0.32.0-linux64.tar.gz
-      rm geckodriver-v0.32.0-linux64.tar.gz
-      mv geckodriver /usr/sbin
-      if [ -e /usr/bin/geckodriver ]
-      then
-        rm /usr/bin/geckodriver
-      fi
-      ln -s /usr/sbin/geckodriver /usr/bin/geckodriver
+    echo "[*] Checking if running as root...";
+    if [ "$EUID" -ne 0 ]; then
+        echo "[-] Error: You must run this setup script with root privileges."
+        echo
+        exit 1
     else
-      wget ${geckodriver_x86_32}
-      tar -xvf geckodriver-v0.32.0-linux32.tar.gz
-      rm geckodriver-v0.32.0-linux32.tar.gz
-      mv geckodriver /usr/sbin
-      if [ -e /usr/bin/geckodriver ]
-      then
-        rm /usr/bin/geckodriver
-      fi
-      ln -s /usr/sbin/geckodriver /usr/bin/geckodriver
+        echo "[+] Running as root."
     fi
-    cd ..
-  ;;
-  # Kali Dependency Installation
-  Kali)
-    apt-get update
-    echo '[*] Installing Debian Dependencies'
-    apt-get install -y cmake python3 xvfb python3-pip python3-netaddr python3-dev firefox-esr
+}
+
+check_system() {
     echo
-    echo '[*] Installing Python Modules'
-    python3 -m pip install fuzzywuzzy
-    python3 -m pip install selenium==4.9.1
-    python3 -m pip install python-Levenshtein
-    python3 -m pip install pyvirtualdisplay
-    python3 -m pip install netaddr
+    echo "[*] Getting system information..."
+    os_id=$(grep ^ID= /etc/os-release | cut -d'=' -f2)
+    mach_type=$(uname -m)
+}
+
+get_gecko() {
     echo
-    cd ../bin/
-    MACHINE_TYPE=`uname -m`
-    if [ ${MACHINE_TYPE} == 'x86_64' ]; then
-      wget ${geckodriver_x86_64}
-      tar -xvf geckodriver-v0.32.0-linux64.tar.gz
-      rm geckodriver-v0.32.0-linux64.tar.gz
-      mv geckodriver /usr/sbin
-      if [ -e /usr/bin/geckodriver ]
-      then
-        rm /usr/bin/geckodriver
-      fi
-      ln -s /usr/sbin/geckodriver /usr/bin/geckodriver
-    else
-      wget ${geckodriver_x86_32}
-      tar -xvf geckodriver-v0.32.0-linux32.tar.gz
-      rm geckodriver-v0.32.0-linux32.tar.gz
-      mv geckodriver /usr/sbin
-      if [ -e /usr/bin/geckodriver ]
-      then
-        rm /usr/bin/geckodriver
-      fi
-      ln -s /usr/sbin/geckodriver /usr/bin/geckodriver
-    fi
-    cd ..
-  ;;
-   # Parrot Dependency Installation
-  Parrot)
-    apt-get update
-    echo '[*] Installing Debian Dependencies'
-    apt-get install -y cmake python3 xvfb python3-pip python3-netaddr python3-dev firefox-esr
+    echo "[*] Getting latest Gecko driver..."
+
+    # Get download links for latest geckodriver via GitHub API
+    local latest_geckos=$(curl -s https://api.github.com/repos/mozilla/geckodriver/releases/latest \
+            | grep browser_download_url | cut -d':' -f2,3 | tr -d \" | tr -d '[:blank:]')
+    
+    # Construct appropriate download URL (or exit if unsupported arch)
+    local gecko_url="";
+    case ${mach_type} in
+        x86_64)
+            gecko_url=$(echo "$latest_geckos" | grep "linux64.tar.gz$");;
+        i386|i686)
+            gecko_url=$(echo "$latest_geckos" | grep "linux32.tar.gz$");;
+        aarch64)
+            gecko_url=$(echo "$latest_geckos" | grep "linux-aarch64.tar.gz$");;
+        *)
+            echo "[-] Error: Unsupported architecture: ${mach_type}"
+            exit 1
+            ;;
+    esac
+
+    # Download, extract, and clean up latest driver tarball
+    wget "$gecko_url" -O geckodriver.tar.gz
+    tar -xvf geckodriver.tar.gz -C /usr/bin
+    rm geckodriver.tar.gz
+}
+
+install_deps() {
     echo
-    echo '[*] Installing Python Modules'
-    python3 -m pip install fuzzywuzzy
-    python3 -m pip install selenium==4.9.1
-    python3 -m pip install python-Levenshtein
-    python3 -m pip install pyvirtualdisplay
-    python3 -m pip install netaddr
+    echo "[*] Installing system dependencies..."
+
+    case ${os_id} in
+        debian|kali)
+            apt update
+            apt install -y wget cmake python3 xvfb python3-pip python3-netaddr python3-dev firefox-esr
+            ;;
+        ubuntu|linuxmint)
+            apt update
+            apt install -y wget cmake python3 xvfb python3-pip python3-netaddr python3-dev firefox x11-utils
+            ;;
+        arch|manjaro)
+            pacman -Syu
+            pacman -S --noconfirm wget cmake python3 python-xvfbwrapper python-pip python-netaddr firefox
+            ;;
+        alpine)
+            apk update
+            apk add wget cmake python3 xvfb py-pip py-netaddr python3-dev firefox
+
+            # from https://stackoverflow.com/questions/58738920/running-geckodriver-in-an-alpine-docker-container
+            # Get all the prereqs
+            wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub
+            wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.30-r0/glibc-2.30-r0.apk
+            wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.30-r0/glibc-bin-2.30-r0.apk
+            apk add glibc-2.30-r0.apk
+            apk add glibc-bin-2.30-r0.apk
+            
+            # And of course we need Firefox if we actually want to *use* GeckoDriver
+            apk add firefox-esr=60.9.0-r0
+            ;;
+        centos|rocky|fedora)
+            yum install -y wget python3 xorg-x11-server-Xvfb python3-pip firefox
+            yum install -y gcc
+            yum install -y cmake
+            yum install -y python3-devel
+            ;;
+        *)
+            echo "[-] Error: Unsupported Operating System ID: ${os_id}"
+            ;;
+    esac
+
+    # PEP 668 workaround
+    PIP_BREAK_SYSTEM_PACKAGES=1
+
     echo
-    cd ../bin/
-    MACHINE_TYPE=`uname -m`
-    if [ ${MACHINE_TYPE} == 'x86_64' ]; then
-      wget ${geckodriver_x86_64}
-      tar -xvf geckodriver-v0.32.0-linux64.tar.gz
-      rm geckodriver-v0.32.0-linux64.tar.gz
-      mv geckodriver /usr/sbin
-      if [ -e /usr/bin/geckodriver ]
-      then
-        rm /usr/bin/geckodriver
-      fi
-      ln -s /usr/sbin/geckodriver /usr/bin/geckodriver
-    else
-      wget ${geckodriver_x86_32}
-      tar -xvf geckodriver-v0.32.0-linux32.tar.gz
-      rm geckodriver-v0.32.0-linux32.tar.gz
-      mv geckodriver /usr/sbin
-      if [ -e /usr/bin/geckodriver ]
-      then
-        rm /usr/bin/geckodriver
-      fi
-      ln -s /usr/sbin/geckodriver /usr/bin/geckodriver
-    fi
-    cd ..
-  ;;
-  # Debian 7+ Dependency Installation
-  Debian)
-    apt-get update
-    echo '[*] Installing Debian Dependencies'
-    apt-get install -y cmake python3 xvfb python3-pip python3-netaddr python3-dev firefox-esr
-    echo
-    echo '[*] Installing Python Modules'
-    python3 -m pip install fuzzywuzzy
-    python3 -m pip install selenium==4.9.1
-    python3 -m pip install python-Levenshtein
-    python3 -m pip install pyvirtualdisplay
-    python3 -m pip install netaddr
-    echo
-    cd ../bin/
-    MACHINE_TYPE=`uname -m`
-    if [ ${MACHINE_TYPE} == 'x86_64' ]; then
-      wget ${geckodriver_x86_64}
-      tar -xvf geckodriver-v0.32.0-linux64.tar.gz
-      rm geckodriver-v0.32.0-linux64.tar.gz
-      mv geckodriver /usr/sbin
-      if [ -e /usr/bin/geckodriver ]
-      then
-        rm /usr/bin/geckodriver
-      fi
-      ln -s /usr/sbin/geckodriver /usr/bin/geckodriver
-    else
-      wget ${geckodriver_x86_32}
-      tar -xvf geckodriver-v0.32.0-linux32.tar.gz
-      rm geckodriver-v0.32.0-linux32.tar.gz
-      mv geckodriver /usr/sbin
-      if [ -e /usr/bin/geckodriver ]
-      then
-        rm /usr/bin/geckodriver
-      fi
-      ln -s /usr/sbin/geckodriver /usr/bin/geckodriver
-    fi
-    cd ..
-  ;;
-  # Ubuntu (tested in 13.10) Dependency Installation
-  Ubuntu)
-    apt-get update
-    echo '[*] Installing Ubuntu Dependencies'
-    apt-get install -y cmake python3 xvfb python3-pip python3-netaddr python3-dev firefox x11-utils
+    echo "[*] Installing Python dependencies..."
     pip3 install --upgrade pip
-    echo
-    echo '[*] Installing Python Modules'
-    python3 -m pip install fuzzywuzzy
-    python3 -m pip install selenium==4.9.1
-    python3 -m pip install python-Levenshtein
-    python3 -m pip install pyvirtualdisplay
-    python3 -m pip install netaddr
-    echo
-    cd ../bin/
-    MACHINE_TYPE=`uname -m`
-    if [ ${MACHINE_TYPE} == 'x86_64' ]; then
-      wget ${geckodriver_x86_64}
-      tar -xvf geckodriver-v0.32.0-linux64.tar.gz
-      rm geckodriver-v0.32.0-linux64.tar.gz
-      mv geckodriver /usr/sbin
-      if [ -e /usr/bin/geckodriver ]
-      then
-        rm /usr/bin/geckodriver
-      fi
-      ln -s /usr/sbin/geckodriver /usr/bin/geckodriver
-    else
-      wget ${geckodriver_x86_32}
-      tar -xvf geckodriver-v0.32.0-linux32.tar.gz
-      rm geckodriver-v0.32.0-linux32.tar.gz
-      mv geckodriver /usr/sbin
-      if [ -e /usr/bin/geckodriver ]
-      then
-        rm /usr/bin/geckodriver
-      fi
-      ln -s /usr/sbin/geckodriver /usr/bin/geckodriver
-    fi
-    cd ..
-  ;;
-  # Arch or Manjaro Dependency Installation
-  Arch | Manjaro)
-    pacman -Syu
-    echo '[*] Installing Arch Dependencies'
-    for pkg_name in cmake python3 python-xvfbwrapper python-pip python-netaddr firefox; do
-        pacman -S --noconfirm "${pkg_name}"
-    done
-    echo
-    echo '[*] Installing Python Modules'
-    python3 -m pip install fuzzywuzzy
-    python3 -m pip install selenium==4.9.1
-    python3 -m pip install python-Levenshtein
-    python3 -m pip install pyvirtualdisplay
-    python3 -m pip install netaddr
-    echo
-    cd ../bin/
-    MACHINE_TYPE=`uname -m`
-    if [ ${MACHINE_TYPE} == 'x86_64' ]; then
-      wget ${geckodriver_x86_64}
-      tar -xvf geckodriver-v0.32.0-linux64.tar.gz
-      rm geckodriver-v0.32.0-linux64.tar.gz
-      mv geckodriver /usr/bin
-    else
-      wget ${geckodriver_x86_32}
-      tar -xvf geckodriver-v0.32.0-linux32.tar.gz
-      rm geckodriver-v0.32.0-linux32.tar.gz
-      mv geckodriver /usr/bin
-    fi
-    cd ..
-  ;;
-  # Alpine Dependency Installation
-  Alpine)
-    apk update
-    echo '[*] Installing Alpine Dependencies'
-    apk add cmake python3 xvfb py-pip py-netaddr python3-dev firefox
-    echo
-    echo '[*] Installing Python Modules'
-    python3 -m pip install fuzzywuzzy
-    python3 -m pip install selenium==4.9.1
-    python3 -m pip install python-Levenshtein
-    python3 -m pip install pyvirtualdisplay
-    python3 -m pip install netaddr
-    echo
-    # from https://stackoverflow.com/questions/58738920/running-geckodriver-in-an-alpine-docker-container
-    # Get all the prereqs
-    wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub
-    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.30-r0/glibc-2.30-r0.apk
-    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.30-r0/glibc-bin-2.30-r0.apk
-    apk add glibc-2.30-r0.apk
-    apk add glibc-bin-2.30-r0.apk
+    python3 -m pip install -r requirements.txt
 
-    # And of course we need Firefox if we actually want to *use* GeckoDriver
-    apk add firefox-esr=60.9.0-r0
+    unset PIP_BREAK_SYSTEM_PACKAGES
+}
 
-    cd ../bin/
-    MACHINE_TYPE=`uname -m`
-    if [ ${MACHINE_TYPE} == 'x86_64' ]; then
-      wget ${geckodriver_x86_64}
-      tar -xvf geckodriver-v0.32.0-linux64.tar.gz -C /usr/bin
-      rm geckodriver-v0.32.0-linux64.tar.gz
-    else
-      wget ${geckodriver_x86_32}
-      tar -xvf geckodriver-v0.32.0-linux32.tar.gz -C /usr/bin
-      rm geckodriver-v0.32.0-linux32.tar.gz
-    fi
-    cd ..
-  ;;
-  # CentOS 7 Dependency Installation
-  CentOS7)
-    echo '[*] Installing Centos 7 Dependencies'
-    yum install -y python3 xorg-x11-server-Xvfb python3-pip firefox
+done_success() {
     echo
-    echo '[*] Installing Centos 7 Build Dependencies'
-    build_pkg=
-    for pkg_name in gcc cmake python3-devel; do
-      yum list installed 2>/dev/null | grep -q "^${pkg_name}\."
-      if [ $? -eq 1 ]; then
-        yum install -y ${pkg_name}
-        build_pkg="${build_pkg} $pkg_name"
-      fi
-    done
+    echo "[+] Setup script completed successfully. Enjoy EyeWitness! ^_^"
+    echo "[*] Be sure to check out Red Siege!"
+    echo "[*] https://www.redsiege.com"
     echo
-    echo '[*] Installing Python Modules'
-    python3 -m pip install fuzzywuzzy
-    python3 -m pip install selenium==4.9.1
-    python3 -m pip install python-Levenshtein
-    python3 -m pip install pyvirtualdisplay
-    python3 -m pip install netaddr
-    echo
-    cd ../bin/
-    MACHINE_TYPE=`uname -m`
-    if [ ${MACHINE_TYPE} == 'x86_64' ]; then
-      #curl because wget is not installed by default
-      curl ${geckodriver_x86_64} -LO
-      tar -xvf geckodriver-v0.32.0-linux64.tar.gz
-      rm -f geckodriver-v0.32.0-linux64.tar.gz
-      mv -f geckodriver /usr/sbin
-      if [ -e /usr/bin/geckodriver ]
-      then
-        rm -f /usr/bin/geckodriver
-      fi
-      ln -s /usr/sbin/geckodriver /usr/bin/geckodriver
-    else
-      curl ${geckodriver_x86_32} -LO
-      tar -xvf geckodriver-v0.32.0-linux32.tar.gz
-      rm -f geckodriver-v0.32.0-linux32.tar.gz
-      mv -f geckodriver /usr/sbin
-      if [ -e /usr/bin/geckodriver ]
-      then
-        rm -f /usr/bin/geckodriver
-      fi
-      ln -s /usr/sbin/geckodriver /usr/bin/geckodriver
-    fi
-    echo
-    echo '[*] Clean Centos 7 Install Dependencies'
-    yum remove -y ${build_pkg}
-    cd ..
-  ;;
-  # Rocky Linux 8 Dependency Installation
-  RockyLinux8)
-    echo '[*] Installing Rocky Linux 8 Dependencies'
-    dnf install -y python3 xorg-x11-server-Xvfb python3-pip python3-netaddr firefox
-    echo
-    echo '[*] Installing Rocky Linux 8 Build Dependencies'
-    build_pkg=
-    for pkg_name in gcc cmake python3-devel; do
-      dnf list installed 2>/dev/null | grep -q "^${pkg_name}\."
-      if [ $? -eq 1 ]; then
-        dnf install -y ${pkg_name}
-        build_pkg="${build_pkg} $pkg_name"
-      fi
-    done
-    echo
-    echo '[*] Installing Python Modules'
-    python3 -m pip install fuzzywuzzy
-    python3 -m pip install selenium==4.9.1
-    python3 -m pip install python-Levenshtein
-    python3 -m pip install pyvirtualdisplay
-    echo
-    cd ../bin/
-    MACHINE_TYPE=`uname -m`
-    if [ ${MACHINE_TYPE} == 'x86_64' ]; then
-      #curl because wget is not installed by default
-      curl ${geckodriver_x86_64} -LO
-      tar -xvf geckodriver-v0.32.0-linux64.tar.gz
-      rm -f geckodriver-v0.32.0-linux64.tar.gz
-      mv -f geckodriver /usr/sbin
-      if [ -e /usr/bin/geckodriver ]
-      then
-        rm -f /usr/bin/geckodriver
-      fi
-      ln -s /usr/sbin/geckodriver /usr/bin/geckodriver
-    else
-      curl ${geckodriver_x86_32} -LO
-      tar -xvf geckodriver-v0.32.0-linux32.tar.gz
-      rm -f geckodriver-v0.32.0-linux32.tar.gz
-      mv -f geckodriver /usr/sbin
-      if [ -e /usr/bin/geckodriver ]
-      then
-        rm -f /usr/bin/geckodriver
-      fi
-      ln -s /usr/sbin/geckodriver /usr/bin/geckodriver
-    fi
-    echo
-    echo '[*] Clean Rocky Linux 8 Install Dependencies'
-    dnf remove -y ${build_pkg}
-    cd ..
-  ;;
-  # Notify Manual Installation Requirement And Exit
-  *)
-    case ${distinfo} in
-    # Mint Dependency Installation
-    Mint)
-      apt-get update
-      echo '[*] Installing Mint Dependencies'
-      apt-get install -y cmake python3 xvfb python3-pip python3-netaddr python3-dev firefox x11-utils
-      pip3 install --upgrade pip
-      echo
-      echo '[*] Installing Python Modules'
-      python3 -m pip install fuzzywuzzy
-      python3 -m pip install selenium==4.9.1
-      python3 -m pip install python-Levenshtein
-      python3 -m pip install pyvirtualdisplay
-      python3 -m pip install netaddr
-      echo
-      cd ../bin/
-      MACHINE_TYPE=`uname -m`
-      if [ ${MACHINE_TYPE} == 'x86_64' ]; then
-        wget ${geckodriver_x86_64}
-        tar -xvf geckodriver-v0.32.0-linux64.tar.gz
-        rm geckodriver-v0.32.0-linux64.tar.gz
-        mv geckodriver /usr/sbin
-        if [ -e /usr/bin/geckodriver ]
-        then
-          rm /usr/bin/geckodriver
-        fi
-        ln -s /usr/sbin/geckodriver /usr/bin/geckodriver
-      else
-        wget ${geckodriver_x86_32}
-        tar -xvf geckodriver-v0.32.0-linux32.tar.gz
-        rm geckodriver-v0.32.0-linux32.tar.gz
-        mv geckodriver /usr/sbin
-        if [ -e /usr/bin/geckodriver ]
-        then
-          rm /usr/bin/geckodriver
-        fi
-        ln -s /usr/sbin/geckodriver /usr/bin/geckodriver
-      fi
-      cd ..
-    ;;
-    *)
-      echo "[Error]: ${osinfo} is not supported by this setup script."
-      echo
-      popd > /dev/null
-      exit 1
-  esac
-esac
+}
 
-# Finish Message
-popd > /dev/null
-echo '[*] Setup script completed successfully, enjoy EyeWitness! :)'
-echo '[*] Be sure to check out Red Siege!'
-echo '[*] https://www.redsiege.com'
-echo
+# check root
+require_root;
+check_system;
+get_gecko;
+install_deps;
+done_success;

--- a/Python/setup/setup.sh
+++ b/Python/setup/setup.sh
@@ -74,15 +74,10 @@ install_deps() {
             ;;
     esac
 
-    # PEP 668 workaround
-    export PIP_BREAK_SYSTEM_PACKAGES=1
-
     echo
     echo "[*] Installing Python dependencies..."
     pip3 install --upgrade pip
     python3 -m pip install -r requirements.txt
-
-    unset PIP_BREAK_SYSTEM_PACKAGES
 }
 
 done_success() {


### PR DESCRIPTION
## Intro
Closes #639. This is the rewritten setup.sh script for the Python version of EyeWitness.

Note that this does not close issue 636. I had naively put in a hack fix to force pip to break system packages but after discussion on that issue, I decided it needed more R&D to determine the best solution. 

## Changes
Notable changes/features are as follows:

1. Reduced code redundancy
2. Refactored Python dependencies to a requirements.txt file
3. Cleaned up global variables
4. Adjusted how OS version is determined and matched for
5. Cleaned up and improved geckodriver retrieval (closes #635)
    1. Removed static geckodriver version in lieu of a call to the GitHub API to get the latest version of geckodriver (closes #601)
        - In case this one is controversial: looking back at the geckodriver related issues shows a clear trend of "upgrading geckodriver" being the fix. to the reported issue.
        - I don't see a reason to anchor a static version that needs to be updated, but I'm happy to hear arguments to the contrary.
    2. Bolstered logic for CPU architecture checks for geckodriver. Adds aarch64 support (closes #577)
6. Other slight quality-of-life tweaks

## Testing
Testing has been performed and the setup is confirmed to work on the following operating systems:

- Debian 12
- Ubuntu 22.04.3
- Linux Mint
- Parrot Security
- Kali Rolling
- CentOS Stream 9
- Rocky 9

Testing was performed on Fedora 39 but encountered errors that couldn't be bypassed with the simple PEP 668 hack (that I removed from this PR, more research is needed).

I have __not__ thoroughly tested on:

- CentOS 7
    - I was unable to get an installation ISO to launch, but I think it will work if it worked on Stream 9.
- Alpine
    - I tried to get an Alpine VM set up but I was unsuccessful.
    - That said, I didn't end up changing anything in the dependency installation for Alpine from the original setup.sh. If I manage to get a good setup going, I might revisit that in the future to see if we can't use a newer version of Firefox, among other things.
- Arch/Manjaro
    -  I have not yet been able to get a good Arch or Manjaro image on the aarch64 system I'm working with.
    - That said, yada yada same boat as Alpine.

If anybody would like to try and test the setup script on a CentOS 7, Alpine, Arch, or Manjaro machine, please let me know if you run into any snags.

Please let me know if you have any remarks on this. It's a pretty big change and I certainly don't want to undo a lot of existing work without a good chance for people to give feedback.

Thanks!