### PR TITLE
Cleanly Exit Single Mode Upon Ctrl+C

### DIFF
--- a/Python/EyeWitness.py
+++ b/Python/EyeWitness.py
@@ -227,6 +227,15 @@ def create_cli_parser():
 
 def single_mode(cli_parsed):
     display = None
+    
+    def exitsig(*args):
+        if current_process().name == 'MainProcess':
+            print('')
+            print('Quitting...')
+        os._exit(1)
+
+    signal.signal(signal.SIGINT, exitsig)
+
     if cli_parsed.web:
         create_driver = selenium_module.create_driver
         capture_host = selenium_module.capture_host


### PR DESCRIPTION
Closes #632.

Adds similar signal handler as `multi_mode` function into `single_mode` function. Does not remove created directory, though I can look at adding that if desirable.

Tested on Parrot Security.