### PR TITLE
Specify window (image/screenshot) size

### DIFF
--- a/Python/EyeWitness.py
+++ b/Python/EyeWitness.py
@@ -131,6 +131,10 @@ def create_cli_parser():
                               help='Selenium geckodriver log path')
     http_options.add_argument('--cookies', metavar='key1=value1,key2=value2', default=None,
                               help='Additional cookies to add to the request')
+    http_options.add_argument('--width', metavar="1366", default=1366,type=int,
+                              help='Screenshot window image width size. 600-7680 (eg. 1920)')
+    http_options.add_argument('--height', metavar="768", default=768, type=int,
+                              help='Screenshot window image height size. 400-4320 (eg. 1080)')
 
     resume_options = parser.add_argument_group('Resume Options')
     resume_options.add_argument('--resume', metavar='ew.db',
@@ -152,6 +156,16 @@ def create_cli_parser():
 
     if ((args.f is not None) and not os.path.isfile(args.f)) or ((args.x is not None) and not os.path.isfile(args.x)):
         print("[*] Error: You didn't specify the correct path to a file. Try again!\n")
+        parser.print_help()
+        sys.exit()
+
+    if args.width < 600 or args.width >7680:
+        print("\n[*] Error: Specify a width >= 600 and <= 7680, for example 1920.\n")
+        parser.print_help()
+        sys.exit()
+
+    if args.height < 400 or args.height >4320:
+        print("\n[*] Error: Specify a height >= 400 and <= 4320, for example, 1080.\n")
         parser.print_help()
         sys.exit()
 

--- a/Python/modules/objects.py
+++ b/Python/modules/objects.py
@@ -277,8 +277,8 @@ class HTTPTableObject(object):
             html += ("""<br><br><a href=\"{0}\"
                 target=\"_blank\">Source Code</a></div></td>
                 <td><div id=\"screenshot\"><a href=\"{1}\"
-                target=\"_blank\"><img src=\"{1}\"
-                height=\"400\"></a></div></td></tr>""").format(
+                target=\"_blank\"><img style=\"max-height:400px;height: expression(this.height > 400 ? 400: true);\"
+                src=\"{1}\"></a></div></td></tr>""").format(
                 src_path, scr_path)
 
         if len(self._uadata) > 0:
@@ -439,8 +439,8 @@ class UAObject(HTTPTableObject):
             html += ("""<br><br><a href=\"{0}\"
                 target=\"_blank\">Source Code</a></div></td>
                 <td><div id=\"screenshot\"><a href=\"{1}\"
-                target=\"_blank\"><img src=\"{1}\"
-                height=\"400\"></a></div></td></tr>""").format(
+                target=\"_blank\"><img style=\"max-height:400px;height: expression(this.height > 400 ? 400: true);\"
+                src=\"{1}\"></a></div></td></tr>""").format(
                 src_path, scr_path)
         return html
 

--- a/Python/modules/selenium_module.py
+++ b/Python/modules/selenium_module.py
@@ -78,6 +78,7 @@ def create_driver(cli_parsed, user_agent=None):
         profile.update_preferences()
         driver = webdriver.Firefox(profile, capabilities=capabilities, options=options, service_log_path=cli_parsed.selenium_log_path)
         driver.set_page_load_timeout(cli_parsed.timeout)
+        driver.set_window_size(cli_parsed.width,cli_parsed.height)
         return driver
     except Exception as e:
         if 'Failed to find firefox binary' in str(e):


### PR DESCRIPTION
Allows the specification of window width and height.  sets default 1366x768.  The width and height are restricted with logic to prevent unreasonable report generations. 

The report output (HTML generation) has been modified slightly with CSS to prevent an image size shorter than 400 px from improperly scaling the image width beyond reason.  Any image with height less than 400 will retain its original height and scale the width accordingly.   The logic should prevent specifying an image height of less than 400, but since the argument specifies the window size, not image size, a 400 specification will produce an actual image less than 400 tall.

Apologies on the silly commit message, I squashed and didn't realize it retained the last message

closes #584 


# Example: 
## Default specification (1366,768)
![image](https://github.com/RedSiege/EyeWitness/assets/29710634/cc42090d-f692-4e42-9259-c16beaf999fb)

## width = 600 height = 1000 (odd size)
![image](https://github.com/RedSiege/EyeWitness/assets/29710634/35f2fd24-533d-4ab2-a349-f231f600d6b2)

## width = 1920 height = 1080 (typical desktop)
![image](https://github.com/RedSiege/EyeWitness/assets/29710634/02578f8b-14ef-49b3-b33e-ee248f2b871f)

## width = 1920 height = 4096 (a "long" screenshot)
![image](https://github.com/RedSiege/EyeWitness/assets/29710634/8b227711-0882-470f-9007-62f72979cb5b)
