### PR TITLE
Malformed URL (from deleted head 605)

### DIFF
--- a/Python/modules/helpers.py
+++ b/Python/modules/helpers.py
@@ -396,6 +396,10 @@ def textfile_parser(file_to_parse, cli_obj):
                         openports[80] += "," + url_again
                     else:
                         openports[80] = url_again
+            if ' ' in url_again.strip():
+                    print("ERROR: You potentially provided an mal-formed URL!")
+                    print("ERROR: URL is - " + url_again)
+                    sys.exit()
 
         # Start prepping to write out the CSV
         csv_data = "URL"

--- a/Python/modules/helpers.py
+++ b/Python/modules/helpers.py
@@ -371,17 +371,20 @@ def textfile_parser(file_to_parse, cli_obj):
             url_again = url_again.strip()
             complete_urls.append(url_again)
             if url_again.count(":") == 2:
-                try:
-                    port_number = int(url_again.split(":")[2].split("/")[0])
-                except ValueError:
-                    print("ERROR: You potentially provided an mal-formed URL!")
-                    print("ERROR: URL is - " + url_again)
-                    sys.exit()
-                hostname_again = url_again.split(":")[0] + ":" + url_again.split(":")[1] + ":" + url_again.split(":")[2]
-                if port_number in openports:
-                    openports[port_number] += "," + hostname_again
-                else:
-                    openports[port_number] = hostname_again
+                char = url_again.split(":")[2].split("/")[0]
+                check = char.isdigit()
+                if check == True:                   
+                    try:
+                        port_number = int(url_again.split(":")[2].split("/")[0])
+                    except ValueError:
+                        print("ERROR: You potentially provided an mal-formed URL!")
+                        print("ERROR: URL is - " + url_again)
+                        sys.exit()
+                    hostname_again = url_again.split(":")[0] + ":" + url_again.split(":")[1] + ":" + url_again.split(":")[2]
+                    if port_number in openports:
+                        openports[port_number] += "," + hostname_again
+                    else:
+                        openports[port_number] = hostname_again
             else:
                 if "https://" in url_again:
                     if 443 in openports:


### PR DESCRIPTION
 original #605 from deleted head branch/repo.

Addresses #656 -- maybe.  The example in the issue post from rengine-ng https://github.com/Security-Tools-Alliance/rengine-ng/issues/15 provided a sample URL that itself appeared legitimately malformed with a space in the URL.  For the sake of this MR, I have to assume that was accidental and wasn't the cause of bringing #605 back up.   

The example provided in #605 is fixed by the proposed changes from #605 and now here.

MR #659 addresses not-malformed URL from #605 by acknowledging it is not malformed

```
http://vimeo.com/api/oembed.json?url=/web/20131219172814/http://vimeo.com/80375746&api=1&amp;player_id=preroll&height=354&width=630&callback
```

Screenshot: 

![image](https://github.com/RedSiege/EyeWitness/assets/29710634/7fc5ac89-1b28-4d41-a27d-98c5509d9f17)
