### PR TITLE
move stylesheet to file

### DIFF
--- a/Python/bin/style.css
+++ b/Python/bin/style.css
@@ -1,0 +1,44 @@
+img {
+    max-width: 100%;
+    height: auto;
+}
+
+#screenshot {
+    max-width: 850px;
+    max-height: 550px;
+    display: inline-block;
+    width: 850px;
+    overflow: scroll;
+}
+
+.hide {
+    display: none;
+}
+
+.uabold {
+    font-weight: bold;
+    cursor: pointer;
+    background-color: green;
+}
+
+.uared {
+    font-weight: bold;
+    cursor: pointer;
+    background-color: red;
+}
+
+table.toc_table {
+    border-collapse: collapse;
+    border: 1px solid black;
+}
+
+    table.toc_table td {
+        border: 1px solid black;
+        padding: 3px 8px 3px 8px;
+    }
+
+    table.toc_table th {
+        border: 1px solid black;
+        text-align: left;
+        padding: 3px 8px 3px 8px;
+    }

--- a/Python/modules/helpers.py
+++ b/Python/modules/helpers.py
@@ -677,44 +677,6 @@ def create_folders_css(cli_parsed):
     Args:
         cli_parsed (ArgumentParser): CLI Object
     """
-    css_page = """img {
-    max-width:100%;
-    height:auto;
-    }
-    #screenshot{
-    max-width: 850px;
-    max-height: 550px;
-    display: inline-block;
-    width: 850px;
-    overflow:scroll;
-    }
-    .hide{
-    display:none;
-    }
-    .uabold{
-    font-weight:bold;
-    cursor:pointer;
-    background-color:green;
-    }
-    .uared{
-    font-weight:bold;
-    cursor:pointer;
-    background-color:red;
-    }
-    table.toc_table{
-    border-collapse: collapse;
-    border: 1px solid black;
-    }
-    table.toc_table td{
-    border: 1px solid black;
-    padding: 3px 8px 3px 8px;
-    }
-    table.toc_table th{
-    border: 1px solid black;
-    text-align: left;
-    padding: 3px 8px 3px 8px;
-    }
-    """
 
     # Create output directories
     if os.path.exists(cli_parsed.d):
@@ -723,16 +685,17 @@ def create_folders_css(cli_parsed):
     os.makedirs(os.path.join(cli_parsed.d, 'screens'))
     os.makedirs(os.path.join(cli_parsed.d, 'source'))
     local_path = os.path.dirname(os.path.realpath(__file__))
-    # Move our jquery and bootstrap file to the local directory
+
+    # Move our jquery & css files to the local directory
     shutil.copy2(
         os.path.join(local_path, '..', 'bin', 'jquery-3.7.1.min.js'), cli_parsed.d)
 
     shutil.copy2(
         os.path.join(local_path, '..', 'bin', 'bootstrap.min.css'), cli_parsed.d)
 
-    # Write our stylesheet to disk
-    with open(os.path.join(cli_parsed.d, 'style.css'), 'w') as f:
-        f.write(css_page)
+    shutil.copy2(
+        os.path.join(local_path, '..', 'bin', 'style.css'), cli_parsed.d)
+
 
 
 def default_creds_category(http_object):

--- a/Python/modules/reporting.py
+++ b/Python/modules/reporting.py
@@ -293,6 +293,7 @@ def create_web_index_head(date, time):
     return ("""<html>
         <head>
         <link rel=\"stylesheet\" href=\"bootstrap.min.css\" type=\"text/css\"/>
+        <link rel=\"stylesheet\" href=\"style.css\" type=\"text/css\"/>
         <title>EyeWitness Report</title>
         <script src="jquery-3.7.1.min.js"></script>
         <script type="text/javascript">


### PR DESCRIPTION
Closes #557 & addresses the missing style.css link.

- Moves style to style.css
- Copies style to report folder
- Links style.css in report html

## Screenshots:

### Running: 
![image](https://github.com/RedSiege/EyeWitness/assets/29710634/cafe2783-198f-46b4-990d-ae0c75c06a96)

### Report with style.css link:
![image](https://github.com/RedSiege/EyeWitness/assets/29710634/56c9ebce-f7a3-49d6-a59d-e4b8c1ef1929)

