### PR TITLE
handle timeouts from urllib (headers/source)

### DIFF
--- a/Python/modules/objects.py
+++ b/Python/modules/objects.py
@@ -262,8 +262,14 @@ class HTTPTableObject(object):
             </tr>
             """)
         elif self.error_state == 'Timeout':
-            html += ("""</td><td>Hit timeout limit while attempting to
-            screenshot</td></tr>""")
+            html += ("</td><td>Hit timeout limit")
+            if os.path.isfile(self.screenshot_path):
+                html += ("""<br>
+                <div id=\"screenshot\"><a href=\"{1}\"
+                target=\"_blank\"><img style=\"max-height:400px;height: expression(this.height > 400 ? 400: true);\"
+                src=\"{1}\"></a></div></td></tr>""").format(src_path, scr_path)
+            else:
+                html += ("</td></tr>")
         elif self.error_state == 'BadStatus':
             html += ("""</td><td>Unknown error while attempting to
             screenshot</td></tr>""")

--- a/Python/modules/selenium_module.py
+++ b/Python/modules/selenium_module.py
@@ -219,9 +219,9 @@ def capture_host(cli_parsed, http_object, driver, ua=None):
             req.set_proxy(str(cli_parsed.proxy_ip) + ':' + str(cli_parsed.proxy_port), 'http')
             req.set_proxy(str(cli_parsed.proxy_ip) + ':' + str(cli_parsed.proxy_port), 'https')
         if context is None:
-            opened = urllib.request.urlopen(req)
+            opened = urllib.request.urlopen(req, timeout=cli_parsed.timeout)
         else:
-            opened = urllib.request.urlopen(req, context=context)
+            opened = urllib.request.urlopen(req,timeout=cli_parsed.timeout, context=context)
         headers = dict(opened.info())
         headers['Response Code'] = str(opened.getcode())
     except urllib.error.HTTPError as e:
@@ -265,6 +265,11 @@ def capture_host(cli_parsed, http_object, driver, ua=None):
         elif e.errno == 10054:
             headers = {'Error': 'Connection Reset'}
             http_object.error_state = 'ConnReset'
+            return http_object, driver
+        elif 'timed out' in str(e):
+            headers = {'Error': 'Timed Out'}
+            http_object.error_state = 'Timeout'
+            print('[*] Socket Timeout when connecting to {0}'.format(http_object.remote_system))
             return http_object, driver
         else:
             http_object.error_state = 'BadStatus'


### PR DESCRIPTION
When a website uses agressive means to bot-check, selenium may properly capture a screenshot, but use of urllib to capture headers/source may stall out (probably on something like a javascript challenge).  Changes below force urllib to timeout according to the timeout argument.  If you do not force urllib to timeout, python can sit indefinitely if there is no fallback env-var timeout for it to use.

closes #667 

The report (objects.py) is also updated to reflect the possibility that a screenshot may have been captured even if urllib was forced into a timeout condition.  The image will be included on the error section of the report, if it exists.  No screenshot is shown if selenium also timed out.  Because no source was captured when urllib is forced into timeout, its not possible to categorize the host into another category.  There might be some scenario where we want to pull these forced-timeouts into a different report section, but for now Error seems appropriate.

The example "hotels.com" is shown below.  hotels.com will load in a browser, but will indefinitely hang urllib and curl if no env-var is present to force a timeout.  These code changes pass the command line argument to urllib incase an env var didn't exist.

# running changed code
![image](https://github.com/RedSiege/EyeWitness/assets/29710634/29935f18-124c-4774-b902-a78f1c595e60)

# example of screenshot where urllib timed out but selenium did not
![image](https://github.com/RedSiege/EyeWitness/assets/29710634/60cabd34-cd29-4240-b821-6cefd0be7e11)

