### PR TITLE
add urllib exception handling

### DIFF
--- a/Python/modules/selenium_module.py
+++ b/Python/modules/selenium_module.py
@@ -280,6 +280,14 @@ def capture_host(cli_parsed, http_object, driver, ua=None):
     except sslerr:
         headers = {'Error': 'Invalid SSL Certificate'}
         http_object.ssl_error = True
+    except TypeError:
+        headers = {'Error': 'Communication Error'}
+        http_object.error_state = 'BadStatus'
+        return http_object, driver
+    except Exception:
+        headers = {'Error': 'Communication Error'}
+        http_object.error_state = 'BadStatus'
+        return http_object, driver
 
     try:
         http_object.page_title = 'Unknown' if driver.title == '' else driver.title.encode(

--- a/Python/modules/selenium_module.py
+++ b/Python/modules/selenium_module.py
@@ -309,5 +309,7 @@ def capture_host(cli_parsed, http_object, driver, ua=None):
         print("[*] ERROR: Skipping: " + http_object.remote_system)
     except WebDriverException:
         print("[*] ERROR: Skipping source code capture for: " + http_object.remote_system)
+    except Exception: 
+         print("[*] ERROR: Skipping source code capture for: " + http_object.remote_system)
 
     return http_object, driver


### PR DESCRIPTION
Add handling for TypeError and Exception on urllib call in selenium_module.py -- will catch some unhandled exceptions that we don't often see but also cant' easily troubleshoot/explain.  

Also: although this shouldn't be an issue further -- added Exception class error when attempting to encode the source and store it in a variable.  In theory, EyeWitness shouldn't make it to the point that urllib failed and its trying to encode NoneType (source), but if it happens again, EyeWitness shouldn't error/stack trace.

addresses #660 

Tested with typical sample URLs -- though none would create the exception that this MR intends to resolve.
![image](https://github.com/RedSiege/EyeWitness/assets/29710634/7124fd78-6c2f-4df3-b34e-d30debf02192)

