### PR TITLE
add camera sigs ✨

### DIFF
--- a/Python/categories.txt
+++ b/Python/categories.txt
@@ -797,3 +797,4 @@ function isIE();name="viewport";@keyframes rotate;THESE STYLES MUST|infrastructu
 content="RackStation;RackStation</title>|nas
 <img src="/image/cisco_logo_about.png">;Phone Adapter|voip
 content="SEIKO EPSON">;/IMAGE/EPSONLOGO_NEW.PNG"|printer
+<title>Web Configurator</title>;<iframe id="main_frame"|camera

--- a/Python/signatures.txt
+++ b/Python/signatures.txt
@@ -460,7 +460,7 @@ tnt-fortinet-grid icon-xl;var xhr = new XMLHttpRequest();document.forms[0].usern
 <title>Emerson Network Power| Emerson UPS admin / Liebert
 <div id="loginLogo">;Storage Management Utility|HP Storage Management Utility - manage / !manage
 OpManager;$zoho.salesiq|Zoho Op Manager - admin / admin
-alt="Cisco Device Manager"|Cisco Device Manager - admin / admin 
+alt="Cisco Device Manager"|Cisco Device Manager - admin / admin
 <title>DG Inspector|Digital Guardian - admin / a10
 emc-logo;XtremIO Management</div>|EMC ExtremIO xmsadmin / 123456 or Xtrem10
 <title>Unisphere;Dell Inc|EMC Unisphere - admin / Password123#
@@ -472,3 +472,4 @@ function isIE();name="viewport";@keyframes rotate;THESE STYLES MUST|PowerProtect
 content="RackStation;RackStation</title>|Rackstation / admin : blank
 img src="/image/cisco_logo_about.png">;Phone Adapter|Cisco Phone Adaptor / admin : admin
 content="SEIKO EPSON">;/IMAGE/EPSONLOGO_NEW.PNG"|Epson Printer - no default credentials
+<title>Web Configurator</title>;<iframe id="main_frame"|ACTi Web Configurator Camera / admin:123456 or Admin:123456


### PR DESCRIPTION
Here's a nuclei template to go with it

```yaml
id: acti-web-configurator-default-login

info:
  name: ACTi Web Configurator Default Login
  author: mr-pmillz
  severity: high
  description: ACTi Web Configurator Default Login
  reference:
    - https://customvideosecurity.com/blog/blog-tag/default-acti-password/#:~:text=Please%20add%20this%20link%20to,Avigilon%3A%20admin%2C
  tags: default-credentials,network-camera,camera

http:
  - raw:
      - |+
        GET /cgi-bin/system?USER={{username}}&PWD={{password}}&LOGIN&CHANNEL=1&SYSTEM_INFO HTTP/1.1
        Host: {{Hostname}}
        User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/115.0
        Accept: */*
        Content-Type: application/x-www-form-urlencoded
        Cookie: User=; Pwd=
        Connection: close
    payloads:
      username:
        - admin
        - Admin
      password:
        - 123456
    attack: clusterbomb
    matchers-condition: and
    matchers:
      - type: word
        part: body
        words:
          - "LOGIN='1'"
      - type: status
        status:
        - 200
```