### PR TITLE
Optimize package installation inside Dockerfile

### DIFF
--- a/Python/Dockerfile
+++ b/Python/Dockerfile
@@ -3,7 +3,8 @@ LABEL maintainer Archidote
 
 RUN apt-get update && \
     echo '\e[32m[*] Installing Debian Dependencies...\e[39m' && \ 
-    apt-get install -y git wget cmake python3 xvfb python3-pip python3-netaddr python3-dev firefox-esr python3-venv
+    apt-get install -y git wget cmake python3 xvfb python3-pip python3-netaddr python3-dev firefox-esr python3-venv && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN	git clone --depth 1 https://github.com/RedSiege/EyeWitness.git /EyeWitness
 
@@ -11,7 +12,8 @@ WORKDIR /EyeWitness
 
 RUN echo -e '\e[32m[*] Setting up the EyeWitness Python env (venv and dependencies)...\e[39m"' && \
     python3 -m venv venv && . venv/bin/activate && \ 
-    python3 -m pip install fuzzywuzzy selenium==4.9.1 python-Levenshtein pyvirtualdisplay netaddr && \
-    cd Python/setup && ./setup.sh
+    python3 -m pip install --no-cache-dir fuzzywuzzy selenium==4.9.1 python-Levenshtein pyvirtualdisplay netaddr && \
+    cd Python/setup && ./setup.sh && \
+    rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT ["/bin/bash", "-c", "source /EyeWitness/venv/bin/activate && python3 /EyeWitness/Python/EyeWitness.py -d /tmp/out --no-prompt $@"]

--- a/Python/Dockerfile.el7
+++ b/Python/Dockerfile.el7
@@ -19,12 +19,14 @@ COPY setup.sh /tmp/setup.sh
 RUN yum install -y git && \
     git clone --depth 1 https://github.com/RedSiege/EyeWitness.git /home/$USER/EyeWitness && \
     cp /tmp/setup.sh /home/$USER/EyeWitness/Python/setup/setup.sh && \
-    yum remove -y git
+    yum remove -y git && \
+    yum clean all
 
 WORKDIR /home/$USER/EyeWitness
 
 RUN cd Python/setup && \
     ./setup.sh && \
+    yum clean all && \
     cd .. && \
     chown -R $USER:$USER /home/$USER/EyeWitness && \
     mkdir -p /tmp/EyeWitness && \

--- a/Python/Dockerfile.el8
+++ b/Python/Dockerfile.el8
@@ -19,12 +19,14 @@ COPY setup.sh /tmp/setup.sh
 RUN dnf install -y git && \
     git clone --depth 1 https://github.com/RedSiege/EyeWitness.git /home/$USER/EyeWitness && \
     cp /tmp/setup.sh /home/$USER/EyeWitness/Python/setup/setup.sh && \
-    dnf remove -y git
+    dnf remove -y git && \
+    dnf clean all
 
 WORKDIR /home/$USER/EyeWitness
 
 RUN cd Python/setup && \
     ./setup.sh && \
+    dnf clean all && \
     cd .. && \
     chown -R $USER:$USER /home/$USER/EyeWitness && \
     mkdir -p /tmp/EyeWitness && \

--- a/Python/setup/setup.sh
+++ b/Python/setup/setup.sh
@@ -52,8 +52,7 @@ install_deps() {
             pacman -S --noconfirm wget curl jq cmake python3 python-xvfbwrapper python-pip python-netaddr firefox tar
             ;;
         alpine)
-            apk update
-            apk add wget curl jq cmake python3 xvfb py-pip py-netaddr python3-dev firefox tar
+            apk add --no-cache wget curl jq cmake python3 xvfb py-pip py-netaddr python3-dev firefox tar
 
             # from https://stackoverflow.com/questions/58738920/running-geckodriver-in-an-alpine-docker-container
             # Get all the prereqs
@@ -62,9 +61,10 @@ install_deps() {
             wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.30-r0/glibc-bin-2.30-r0.apk
             apk add glibc-2.30-r0.apk
             apk add glibc-bin-2.30-r0.apk
+            rm glibc-2.30-r0.apk glibc-bin-2.30-r0.apk
             
             # And of course we need Firefox if we actually want to *use* GeckoDriver
-            apk add firefox-esr=60.9.0-r0
+            apk add --no-cache firefox-esr=60.9.0-r0
             ;;
         centos|rocky|fedora)
             yum install -y wget curl jq python3 xorg-x11-server-Xvfb python3-pip firefox gcc cmake python3-devel gcc cmake python3-devel tar
@@ -78,8 +78,8 @@ install_deps() {
 
     echo
     echo "[*] Installing Python dependencies..."
-    pip3 install --upgrade pip
-    python3 -m pip install -r requirements.txt
+    pip3 install --no-cache-dir --upgrade pip
+    python3 -m pip install --no-cache-dir -r requirements.txt
 }
 
 # Make sure we're in the setup directory


### PR DESCRIPTION
This pull request includes several updates to Dockerfiles and the `setup.sh` script to improve the efficiency and cleanliness of the Docker image build process. The changes focus on cleaning up package lists and using the `--no-cache-dir` option for `pip` installations.

Improvements to Dockerfiles:

* [`Python/Dockerfile`](diffhunk://#diff-01ff54b933a8a4d9119e58207239d79cdd7d5c5988b9ea9674025920777b1b3aL6-R17): Added commands to remove the `apt` package lists after installation and to use `--no-cache-dir` for `pip` installations to reduce image size.
* [`Python/Dockerfile.el7`](diffhunk://#diff-6f993f4803ad71535f04683b564dec035e4baeafaf5d7a7ebf4c207f67ad4497L22-R29): Added `yum clean all` commands to clean up package lists after installation and removal of `git`.
* [`Python/Dockerfile.el8`](diffhunk://#diff-5d27cd1424767053b029012c832a0e6d6a109b2a5a31d4b2feb8a7ce52cd51e1L22-R29): Added `dnf clean all` commands to clean up package lists after installation and removal of `git`.

Improvements to `setup.sh` script:

* [`Python/setup/setup.sh`](diffhunk://#diff-8c71b0d56c2c4f0c43adf7fd95367c113e9d7c5cc32c484348ba872ae3c4eb06L55-R55): Updated `apk` commands to use `--no-cache` option and added removal of temporary `glibc` packages to reduce image size. [[1]](diffhunk://#diff-8c71b0d56c2c4f0c43adf7fd95367c113e9d7c5cc32c484348ba872ae3c4eb06L55-R55) [[2]](diffhunk://#diff-8c71b0d56c2c4f0c43adf7fd95367c113e9d7c5cc32c484348ba872ae3c4eb06R64-R67)
* [`Python/setup/setup.sh`](diffhunk://#diff-8c71b0d56c2c4f0c43adf7fd95367c113e9d7c5cc32c484348ba872ae3c4eb06L81-R82): Added `--no-cache-dir` option to `pip` commands to avoid caching and reduce image size.